### PR TITLE
Fix rebuild()

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -151,7 +151,7 @@ return function (version, reduce, map, codec, initial) {
         }, cb)
       },
       destroy: function (cb) {
-        value.set(null); since.set(-1);
+        value.set(null);
         w.write(null)
         w.close(cb)
       },


### PR DESCRIPTION
Problem: I don't understand why, but when a flumeview runs `destroy()`
it seems like it will remain stuck in a `rebuild()` state if you do
`since.set(-1)`. Other flumeviews don't change `since` during
`destroy()` and they work fine, so my hunch is that flumeviews aren't
supposed to change that value when they're being destroyed.

Solution: Remove `since.set(-1)` from `destroy()`.