### PR TITLE
*Allow* periodic writes of the views to avoid loss of work when restarting

### DIFF
--- a/inject.js
+++ b/inject.js
@@ -143,14 +143,24 @@ return function (version, reduce, map, codec, initial) {
       },
       createSink: function (cb) {
         closeStream = cb;
+        let count = 0
         return Drain(function (data) {
           var _data = map(data.value, data.seq)
           if(_data != null) value.set(reduce(value.value, _data, data.seq))
           since.set(data.seq)
           notify(_data)
-          //if we are now in sync with the log, maybe write.
-          if(since.value === log.since.value)
+
+          // If we are now in sync with the log, write.
+          const inSyncWithLog = since.value === log.since.value
+
+          // Alternatively, write every 10,000 messages.
+          const isTenThousand = count % 10000
+
+          if(inSyncWithLog || isTenThousand) {
             write()
+          }
+
+          count += 1
         }, cb)
       },
       destroy: function (cb) {

--- a/inject.js
+++ b/inject.js
@@ -31,7 +31,7 @@ function isFunction (f) {
 function id (e) { return e }
 
 module.exports = function (Store) {
-return function (version, reduce, map, codec, initial) {
+return function (version, reduce, map, codec, initial, writeInterval = null) {
   var opts
   if(isObject(reduce)) {
     opts = reduce
@@ -154,9 +154,9 @@ return function (version, reduce, map, codec, initial) {
           const inSyncWithLog = since.value === log.since.value
 
           // Alternatively, write every 10,000 messages.
-          const isTenThousand = count % 10000
+          const periodicWrite = writeInterval && count % writeInterval == 0
 
-          if(inSyncWithLog || isTenThousand) {
+          if(inSyncWithLog || periodicWrite) {
             write()
           }
 


### PR DESCRIPTION
This is the commit of #12, but with the count at which the view is persisted being an initialization-time parameter. I just tested that in patchwork and it works nicely
@christianbundy I hope this is less controversial than your PR? I'd love to just bump the version for this repo instead of including the code directly from my fork.